### PR TITLE
LPS-18406 - do not load the whole history module but the required modules only.

### DIFF
--- a/portal-web/docroot/html/js/liferay/history.js
+++ b/portal-web/docroot/html/js/liferay/history.js
@@ -136,11 +136,11 @@ AUI().add(
 			};
 		}
 
-		HistoryManager = new History();
+		var HistoryManager = new History();
 
 		HistoryManager.SRC_ADD = HistoryBase.SRC_ADD;
-		HistoryManager.SRC_HASH = A.HistoryHash.SRC_HASH;
-		HistoryManager.SRC_POPSTATE = A.HistoryHTML5.SRC_POPSTATE;
+		HistoryManager.SRC_HASH = A.HistoryHash ? A.HistoryHash.SRC_HASH : 'hash';
+		HistoryManager.SRC_POPSTATE = A.HistoryHTML5 ? A.HistoryHTML5.SRC_POPSTATE : 'popstate';
 		HistoryManager.SRC_REPLACE = HistoryBase.SRC_REPLACE;
 
 		HistoryManager.HTML5 = HTML5;

--- a/portal-web/docroot/html/js/liferay/modules.js
+++ b/portal-web/docroot/html/js/liferay/modules.js
@@ -51,7 +51,7 @@
 			'dynamic-select': ['aui-base'],
 			'form': ['aui-base', 'aui-form-validator'],
 			'form-navigator': ['aui-base'],
-			'history': ['history', 'querystring'],
+			'history': getHistoryRequirements(),
 			'hudcrumbs': ['aui-base', 'plugin'],
 			'icon': ['aui-base'],
 			'input-move-boxes': ['aui-base', 'aui-toolbar'],
@@ -88,6 +88,29 @@
 		}
 
 		return modules;
+	};
+
+	var getHistoryRequirements = function() {
+		var DOC = A.config.doc;
+
+		var DOCMODE = DOC.documentMode;
+
+		var WIN = A.config.win;
+
+		var requirements = ['history-base', 'querystring-parse-simple', 'querystring-stringify-simple'];
+
+		if (WIN.history && WIN.history.pushState && WIN.history.replaceState && ('onpopstate' in WIN || A.UA.gecko >= 2)) {
+			requirements.push('history-html5');
+		}
+		else {
+			requirements.push('history-hash');
+
+			if (A.UA.ie && !('onhashchange' in WIN || 'onhashchange' in DOC) && (!DOCMODE || DOCMODE > 7)) {
+				requirements.push('history-hash-ie');
+			}
+		}
+
+		return requirements;
 	};
 
 	GROUPS.liferay = {


### PR DESCRIPTION
Hi Nate,

Here is another change - we are loading only those modules, which are really needed and nothing more.
In 'modules.js' requirements are placed in an array, so I had to created a separate function especially for History.
It works in this way, but this is the only module which is doing that so it might work a little bit weird.
