### PR TITLE
LPS-15381 Support for export one single page

### DIFF
--- a/portal-web/docroot/html/portlet/layouts_admin/edit_layout.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/edit_layout.jsp
@@ -17,6 +17,8 @@
 <%@ include file="/html/portlet/layouts_admin/init.jsp" %>
 
 <%
+Locale defaultLocale = LocaleUtil.getDefault();
+
 Group selGroup = (Group)request.getAttribute(WebKeys.GROUP);
 
 Group group = (Group)request.getAttribute("edit_pages.jsp-group");
@@ -158,6 +160,7 @@ String[][] categorySections = {mainSections};
 							var buttonRow = A.one('#<portlet:namespace />layoutToolbar');
 
 							var popup = null;
+							var exportPopup;
 
 							var layoutToolbar = new A.Toolbar(
 								{
@@ -212,7 +215,58 @@ String[][] categorySections = {mainSections};
 											},
 											icon: 'circle-minus',
 											label: '<liferay-ui:message key="delete" />'
-										}
+										},
+										<c:if test="<%= GroupPermissionUtil.contains(permissionChecker, liveGroupId, ActionKeys.MANAGE_LAYOUTS) %>">
+											{
+												type: 'ToolbarSpacer'
+											},
+											{
+												handler: function(event) {
+													if (!exportPopup) {
+														exportPopup = new A.Dialog(
+															{
+																centered: true,
+																constrain: true,
+																cssClass: 'lfr-export-dialog',
+																modal: true,
+																title: '<liferay-ui:message key="export" />',
+																width: 600
+															}
+														).render();
+
+														<portlet:renderURL var="exportPagesURL" windowState="<%= LiferayWindowState.EXCLUSIVE.toString() %>">
+															<portlet:param name="struts_action" value="/layouts_admin/export_layouts" />
+															<portlet:param name="<%= Constants.CMD %>" value="<%= Constants.EXPORT %>" />
+															<portlet:param name="groupId" value="<%= String.valueOf(groupId) %>" />
+															<portlet:param name="layoutIds" value="<%= String.valueOf(layoutId) %>" />
+															<portlet:param name="liveGroupId" value="<%= String.valueOf(liveGroupId) %>" />
+															<portlet:param name="privateLayout" value="<%= String.valueOf(privateLayout) %>" />
+															<portlet:param name="redirect" value="<%= currentURL %>" />
+															<portlet:param name="rootNodeName" value="<%= selLayout.getName(defaultLocale) %>" />
+														</portlet:renderURL>
+
+														exportPopup.plug(
+															A.Plugin.IO,
+															{
+																after: {
+																	success: function() {
+																		exportPopup.centered();
+																	}
+																},
+																autoLoad: false,
+																uri: '<%= exportPagesURL.toString() %>'
+															}
+														);
+													}
+
+													exportPopup.show();
+
+													exportPopup.io.start();
+												},
+												icon: 'arrowthick-1-b',
+												label: '<liferay-ui:message key="export" />'
+											}
+										</c:if>
 									]
 								}
 							).render();

--- a/portal-web/docroot/html/portlet/layouts_admin/export_import.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/export_import.jsp
@@ -25,6 +25,8 @@ Group group = (Group)request.getAttribute(WebKeys.GROUP);
 
 long groupId = ParamUtil.getLong(request, "groupId");
 
+long[] layoutIds = ParamUtil.getLongValues(request, "layoutIds");
+
 Group liveGroup = group;
 
 if (group.isStagingGroup()) {
@@ -132,6 +134,7 @@ portletsList = ListUtil.sort(portletsList, new PortletTitleComparator(applicatio
 					<portlet:actionURL var="exportPagesURL">
 						<portlet:param name="struts_action" value="/layouts_admin/export_layouts" />
 						<portlet:param name="groupId" value="<%= String.valueOf(liveGroupId) %>" />
+						<portlet:param name="layoutIds" value="<%= StringUtil.merge(layoutIds) %>" />
 						<portlet:param name="privateLayout" value="<%= String.valueOf(privateLayout) %>" />
 					</portlet:actionURL>
 


### PR DESCRIPTION
Added functionality to export only a single page (layout) by adding an export button to ethe toolbar of each page instead of only for public pages. The export code in edit_layout.jsp is adapted from edit_layout_set.jsp
