### PR TITLE
LPS-21972

### DIFF
--- a/portal-service/src/com/liferay/portal/kernel/dao/search/RowChecker.java
+++ b/portal-service/src/com/liferay/portal/kernel/dao/search/RowChecker.java
@@ -94,8 +94,8 @@ public class RowChecker {
 
 	public String getRowCheckBox(boolean checked, String primaryKey) {
 		return getRowCheckBox(
-			checked, _rowIds, primaryKey, "'" + _rowIds + "'", _allRowIds,
-			StringPool.BLANK);
+			checked, _rowIds, primaryKey, "'" + _rowIds + "'",
+			"'" + _allRowIds + "'", StringPool.BLANK);
 	}
 
 	public String getRowId() {

--- a/portal-web/docroot/html/js/liferay/util.js
+++ b/portal-web/docroot/html/js/liferay/util.js
@@ -740,7 +740,7 @@
 			var totalOn = 0;
 			var inputs = A.one(form).all('input[type=checkbox]');
 
-			allBox = A.one(allBox);
+			allBox = A.one(allBox) || A.one(form).all('input[name=' + allBox + ']');
 
 			if (!isArray(name)) {
 				name = [name];


### PR DESCRIPTION
allBox is null when there is multiple search container in the form with checkbox.

Changes:
1. _allRowIds is passed as object instead of string so I added explicit single quote
2. grab allBox inside form where the each checkbox contains (Note: You still need A.one(allBox) for document library)
