### PR TITLE
LPS-22138 - Update Menu to only register unexpanded menus

### DIFF
--- a/util-taglib/src/com/liferay/taglib/ui/IconMenuTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/IconMenuTag.java
@@ -292,13 +292,13 @@ public class IconMenuTag extends BaseBodyTagSupport implements BodyTag {
 					jspWriter.write("<span class=\"taglib-text\">");
 					jspWriter.write(LanguageUtil.get(pageContext, _message));
 					jspWriter.write("</span></a></strong>");
+
+					ScriptTag.doTag(
+						null, "liferay-menu",
+						"Liferay.Menu.register('#" + _id + "');", pageContext);
 				}
 
 				jspWriter.write("<ul>");
-
-				ScriptTag.doTag(
-					null, "liferay-menu",
-					"Liferay.Menu.register('#" + _id + "');", pageContext);
 			}
 			else {
 				PortalIncludeUtil.include(pageContext, getStartPage());


### PR DESCRIPTION
Hey Nate,

Attached are some updates to the menu.js changes we made.  We should only be registering the unexpanded menus since the expanded menus should go through as links as was previously designed.  This ticket relates to:

http://issues.liferay.com/browse/LPS-22138

Please let me know if you have any questions.  Thanks!
- Jon Mak
