### PR TITLE
LPS-23358

### DIFF
--- a/portal-web/docroot/html/js/liferay/portal.js
+++ b/portal-web/docroot/html/js/liferay/portal.js
@@ -119,7 +119,7 @@
 			if (!cached) {
 				cached = new A.Tooltip(
 					{
-						trigger: '.liferay-tooltip',
+						trigger: obj,
 						zIndex: 10000
 					}
 				).render();


### PR DESCRIPTION
LPS-23358 remove '.liferay-tooltip' because it is obsolete, and use obj because we need a trigger to correctly align the tooltip when it is rendered
