### PR TITLE
LPS-23304 - Document Library sort by button unresponsive until the page is refreshed

### DIFF
--- a/portal-web/docroot/html/portlet/document_library/js/main.js
+++ b/portal-web/docroot/html/portlet/document_library/js/main.js
@@ -934,6 +934,8 @@ AUI().add(
 						if (sortButton) {
 							var sortButtonContainer = instance.byId('sortButtonContainer');
 
+							sortButtonContainer.plug(A.Plugin.ParseContent);
+
 							sortButtonContainer.setContent(sortButton);
 						}
 					},


### PR DESCRIPTION
Hey Nate,

Attached are the changes to update the sort by button for the Documents and Media.  The issue can be found at http://issues.liferay.com/browse/LPS-23304 and http://issues.liferay.com/browse/LPS-22517.

Please let me know if you have any questions.  Thanks!
- Jon Mak
