### PR TITLE
LPS-23326 - Remove "entry-title" class from icon taglib

### DIFF
--- a/portal-web/docroot/html/taglib/ui/icon/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/icon/page.jsp
@@ -135,11 +135,11 @@ boolean urlIsNotNull = Validator.isNotNull(url);
 			<liferay-ui:message key="<%= message %>" />
 		</c:when>
 		<c:when test="<%= (iconListIconCount != null) && ((iconListSingleIcon == null) || iconListShowWhenSingleIcon) %>">
-			<span class="entry-title taglib-text"><liferay-ui:message key="<%= message %>" /></span>
+			<span class="taglib-text"><liferay-ui:message key="<%= message %>" /></span>
 		</c:when>
 		<c:otherwise>
 			<c:if test="<%= label %>">
-				<span class="entry-title taglib-text"><liferay-ui:message key="<%= message %>" /></span>
+				<span class="taglib-text"><liferay-ui:message key="<%= message %>" /></span>
 			</c:if>
 		</c:otherwise>
 	</c:choose>


### PR DESCRIPTION
Hey Nate,

Attached are the changes to remove the "entry-title" class title from the icon taglib.  I think this class was added originally begin because Iliyan was trying to leverage the class "entry-title" for a selector to grab the drop target of the Document Library, but he actually changed that selector to use the HTML node attribute "data-table" for the drop target.  This is the commit that he removed the "entry-title" selector (https://github.com/liferay/liferay-portal/blob/3a2683d955aa067c1402361487fa929f4dea0cb9/portal-web/docroot/html/portlet/document_library/js/main.js)

This issue can be found at http://issues.liferay.com/browse/LPS-24018.

Please let me know if you have any questions.  Thanks!
- Jon Mak
