### PR TITLE
LPS-64176 Allow SVG any icon sprites to be used by the aui:icon taglib and the JS utility methods

### DIFF
--- a/portal-web/docroot/html/taglib/aui/icon/init.jsp
+++ b/portal-web/docroot/html/taglib/aui/icon/init.jsp
@@ -25,6 +25,7 @@ java.lang.String id = GetterUtil.getString((java.lang.String)request.getAttribut
 java.lang.String image = GetterUtil.getString((java.lang.String)request.getAttribute("aui:icon:image"));
 java.lang.String label = GetterUtil.getString((java.lang.String)request.getAttribute("aui:icon:label"));
 java.lang.String markupView = GetterUtil.getString((java.lang.String)request.getAttribute("aui:icon:markupView"));
+java.lang.String src = GetterUtil.getString((java.lang.String)request.getAttribute("aui:icon:src"));
 java.lang.String target = GetterUtil.getString((java.lang.String)request.getAttribute("aui:icon:target"));
 java.lang.String url = GetterUtil.getString((java.lang.String)request.getAttribute("aui:icon:url"));
 Map<String, Object> dynamicAttributes = (Map<String, Object>)request.getAttribute("aui:icon:dynamicAttributes");

--- a/portal-web/docroot/html/taglib/aui/icon/lexicon/page.jsp
+++ b/portal-web/docroot/html/taglib/aui/icon/lexicon/page.jsp
@@ -18,7 +18,7 @@
 
 <liferay-util:buffer var="iconContent">
 	<svg class="lexicon-icon lexicon-icon-<%= image %>" role="img" title="<%= HtmlUtil.escapeAttribute(LanguageUtil.get(resourceBundle, label)) %>" <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %>>
-		<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/lexicon/icons.svg#<%= image %>" />
+		<use xlink:href='<%= Validator.isNotNull(src) ? src : themeDisplay.getPathThemeImages().concat("/lexicon/icons.svg") %>#<%= image %>' />
 	</svg>
 
 	<span class="taglib-icon-label">

--- a/util-taglib/src/META-INF/liferay-aui.tld
+++ b/util-taglib/src/META-INF/liferay-aui.tld
@@ -702,6 +702,13 @@
 			<type>java.lang.String</type>
 		</attribute>
 		<attribute>
+			<description><![CDATA[The optional path to a custom SVG file. If not supplied, default icons will be used.]]></description>
+			<name>src</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+			<type>java.lang.String</type>
+		</attribute>
+		<attribute>
 			<description><![CDATA[The target window in which the URL is opened. The default value is <code>self</code>. Possible values are <code>blank</code>, <code>self</code>, <code>parent</code>, <code>top</code>, and a unique frame's name.]]></description>
 			<name>target</name>
 			<required>false</required>

--- a/util-taglib/src/com/liferay/taglib/aui/base/BaseIconTag.java
+++ b/util-taglib/src/com/liferay/taglib/aui/base/BaseIconTag.java
@@ -57,6 +57,10 @@ public abstract class BaseIconTag extends com.liferay.taglib.util.IncludeTag {
 		return _markupView;
 	}
 
+	public java.lang.String getSrc() {
+		return _src;
+	}
+
 	public java.lang.String getTarget() {
 		return _target;
 	}
@@ -101,6 +105,12 @@ public abstract class BaseIconTag extends com.liferay.taglib.util.IncludeTag {
 		setScopedAttribute("markupView", markupView);
 	}
 
+	public void setSrc(java.lang.String src) {
+		_src = src;
+
+		setScopedAttribute("src", src);
+	}
+
 	public void setTarget(java.lang.String target) {
 		_target = target;
 
@@ -123,6 +133,7 @@ public abstract class BaseIconTag extends com.liferay.taglib.util.IncludeTag {
 		_image = null;
 		_label = null;
 		_markupView = null;
+		_src = null;
 		_target = null;
 		_url = null;
 	}
@@ -140,6 +151,7 @@ public abstract class BaseIconTag extends com.liferay.taglib.util.IncludeTag {
 		setNamespacedAttribute(request, "image", _image);
 		setNamespacedAttribute(request, "label", _label);
 		setNamespacedAttribute(request, "markupView", _markupView);
+		setNamespacedAttribute(request, "src", _src);
 		setNamespacedAttribute(request, "target", _target);
 		setNamespacedAttribute(request, "url", _url);
 	}
@@ -155,6 +167,7 @@ public abstract class BaseIconTag extends com.liferay.taglib.util.IncludeTag {
 	private java.lang.String _image = null;
 	private java.lang.String _label = null;
 	private java.lang.String _markupView = null;
+	private java.lang.String _src = null;
 	private java.lang.String _target = null;
 	private java.lang.String _url = null;
 

--- a/util-taglib/src/com/liferay/taglib/aui/base/packageinfo
+++ b/util-taglib/src/com/liferay/taglib/aui/base/packageinfo
@@ -1,1 +1,1 @@
-version 7.0.0
+version 7.1.0

--- a/util-taglib/src/com/liferay/taglib/aui/packageinfo
+++ b/util-taglib/src/com/liferay/taglib/aui/packageinfo
@@ -1,1 +1,1 @@
-version 7.0.0
+version 7.1.0

--- a/util-taglib/src/com/liferay/taglib/liferay-aui.xml
+++ b/util-taglib/src/com/liferay/taglib/liferay-aui.xml
@@ -614,6 +614,12 @@
 				<outputType>java.lang.String</outputType>
 			</attribute>
 			<attribute>
+				<description>The optional path to a custom SVG file. If not supplied, default icons will be used.</description>
+				<name>src</name>
+				<inputType>java.lang.String</inputType>
+				<outputType>java.lang.String</outputType>
+			</attribute>
+			<attribute>
 				<description>The target window in which the URL is opened. The default value is <![CDATA[<code>self</code>]]>. Possible values are <![CDATA[<code>blank</code>]]>, <![CDATA[<code>self</code>]]>, <![CDATA[<code>parent</code>]]>, <![CDATA[<code>top</code>]]>, and a unique frame's name.</description>
 				<name>target</name>
 				<inputType>java.lang.String</inputType>


### PR DESCRIPTION
This is an update for [LPS-64176](https://issues.liferay.com/browse/LPS-64176).<br><br>
