### PR TITLE
LPS-64236 updates error marking in Lexicon form navigator

### DIFF
--- a/portal-web/docroot/html/taglib/aui/fieldset/init-ext.jspf
+++ b/portal-web/docroot/html/taglib/aui/fieldset/init-ext.jspf
@@ -13,7 +13,3 @@
  * details.
  */
 --%>
-
-<%
-String panelId = GetterUtil.getString((java.lang.String)request.getAttribute("aui:fieldset:panelId"));
-%>

--- a/portal-web/docroot/html/taglib/aui/fieldset/lexicon/start.jsp
+++ b/portal-web/docroot/html/taglib/aui/fieldset/lexicon/start.jsp
@@ -23,7 +23,7 @@ if (Validator.isNull(label)) {
 }
 %>
 
-<div aria-labelledby="<%= panelId %>Title" class="<%= collapsible ? "panel panel-default" : StringPool.BLANK %> <%= cssClass %>" <%= Validator.isNotNull(id) ? "id=\"" + namespace + id + "\"" : StringPool.BLANK %> <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %> role="group">
+<div aria-labelledby="<%= id %>Title" class="<%= collapsible ? "panel panel-default" : StringPool.BLANK %> <%= cssClass %>" <%= Validator.isNotNull(id) ? "id=\"" + namespace + id + "\"" : StringPool.BLANK %> <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %> role="group">
 	<c:if test="<%= Validator.isNotNull(label) %>">
 		<liferay-util:buffer var="header">
 			<liferay-ui:message key="<%= label %>" localizeKey="<%= localizeLabel %>" />
@@ -39,11 +39,11 @@ if (Validator.isNull(label)) {
 			</c:if>
 		</liferay-util:buffer>
 
-		<div class="panel-heading" id="<%= panelId %>Header" role="presentation">
-			<div class="panel-title" id="<%= panelId %>Title">
+		<div class="panel-heading" id="<%= id %>Header" role="presentation">
+			<div class="panel-title" id="<%= id %>Title">
 				<c:choose>
 					<c:when test="<%= collapsible %>">
-						<a aria-controls="<%= panelId %>Content" aria-expanded="true" class="collapse-icon collapse-icon-middle <%= collapsed ? "collapsed" : StringPool.BLANK %>" data-toggle="collapse" href="#<%= panelId %>Content" role="button">
+						<a aria-controls="<%= id %>Content" aria-expanded="true" class="collapse-icon collapse-icon-middle <%= collapsed ? "collapsed" : StringPool.BLANK %>" data-toggle="collapse" href="#<%= id %>Content" role="button">
 							<%= header %>
 						</a>
 					</c:when>
@@ -55,5 +55,5 @@ if (Validator.isNull(label)) {
 		</div>
 	</c:if>
 
-	<div aria-labelledby="<%= panelId %>Header" class="<%= !collapsed ? "in" : StringPool.BLANK %> <%= collapsible ? "panel-collapse collapse" : StringPool.BLANK %> <%= column ? "row" : StringPool.BLANK %>" id="<%= panelId %>Content" role="presentation">
+	<div aria-labelledby="<%= id %>Header" class="<%= !collapsed ? "in" : StringPool.BLANK %> <%= collapsible ? "panel-collapse collapse" : StringPool.BLANK %> <%= column ? "row" : StringPool.BLANK %>" id="<%= id %>Content" role="presentation">
 		<div class="panel-body">

--- a/portal-web/docroot/html/taglib/aui/form/end.jsp
+++ b/portal-web/docroot/html/taglib/aui/form/end.jsp
@@ -80,4 +80,6 @@
 	<c:if test="<%= Validator.isNotNull(onSubmit) %>">
 		A.all('#<%= namespace + name %> .input-container').removeAttribute('disabled');
 	</c:if>
+
+	Liferay.fire('<portlet:namespace />formReady');
 </aui:script>

--- a/portal-web/docroot/html/taglib/ui/form_navigator/lexicon/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/form_navigator/lexicon/page.jsp
@@ -42,6 +42,8 @@ for (String categoryKey : categoryKeys) {
 			<%
 			for (String categoryKey : filterCategoryKeys) {
 				List<FormNavigatorEntry<Object>> formNavigatorEntries = FormNavigatorEntryUtil.getFormNavigatorEntries(id, categoryKey, user, formModelBean);
+
+				request.setAttribute("currentTab", categoryKey);
 			%>
 
 				<liferay-ui:section>
@@ -49,6 +51,12 @@ for (String categoryKey : categoryKeys) {
 				</liferay-ui:section>
 
 			<%
+			}
+
+			String errorTab = (String)request.getAttribute("errorTab");
+
+			if (Validator.isNotNull(errorTab)) {
+				request.setAttribute(WebKeys.ERROR_SECTION, errorTab);
 			}
 			%>
 

--- a/portal-web/docroot/html/taglib/ui/form_navigator/lexicon/sections.jspf
+++ b/portal-web/docroot/html/taglib/ui/form_navigator/lexicon/sections.jspf
@@ -113,8 +113,13 @@
 				</c:otherwise>
 			</c:choose>
 
-			if (focusField) {
-				focusField.focus();
+			if (focusField.length) {
+				Liferay.on(
+					'<portlet:namespace />formReady',
+					function(event) {
+						focusField.focus();
+					}
+				);
 			}
 		</aui:script>
 

--- a/portal-web/docroot/html/taglib/ui/form_navigator/lexicon/sections.jspf
+++ b/portal-web/docroot/html/taglib/ui/form_navigator/lexicon/sections.jspf
@@ -90,6 +90,9 @@
 
 	<%
 	if (Validator.isNotNull(errorSection)) {
+		String currentTab = (String)request.getAttribute("currentTab");
+
+		request.setAttribute("errorTab", currentTab);
 	%>
 
 		<aui:script sandbox="<%= true %>">

--- a/portal-web/docroot/html/taglib/ui/form_navigator/lexicon/sections.jspf
+++ b/portal-web/docroot/html/taglib/ui/form_navigator/lexicon/sections.jspf
@@ -82,7 +82,7 @@
 	%>
 
 			<aui:script sandbox="<%= true %>">
-				var sectionContent = $('#<%= errorSection %>Content');
+				var sectionContent = $('#<%= _getSectionId(errorSection) %>Content');
 
 				if (!sectionContent.hasClass('in')) {
 					sectionContent.collapse('show');

--- a/portal-web/docroot/html/taglib/ui/form_navigator/lexicon/sections.jspf
+++ b/portal-web/docroot/html/taglib/ui/form_navigator/lexicon/sections.jspf
@@ -82,10 +82,28 @@
 	%>
 
 			<aui:script sandbox="<%= true %>">
+				var focusField;
 				var sectionContent = $('#<%= _getSectionId(errorSection) %>Content');
 
 				if (!sectionContent.hasClass('in')) {
 					sectionContent.collapse('show');
+				}
+
+				<%
+				String focusField = (String)request.getAttribute("liferay-ui:error:focusField");
+				%>
+
+				<c:choose>
+					<c:when test="<%= Validator.isNotNull(focusField) %>">
+						focusField = sectionContent.find('#<portlet:namespace /><%= focusField %>');
+					</c:when>
+					<c:otherwise>
+						focusField = sectionContent.find('input:not([type="hidden"]).field').first();
+					</c:otherwise>
+				</c:choose>
+
+				if (focusField) {
+					focusField.focus();
 				}
 			</aui:script>
 

--- a/portal-web/docroot/html/taglib/ui/form_navigator/lexicon/sections.jspf
+++ b/portal-web/docroot/html/taglib/ui/form_navigator/lexicon/sections.jspf
@@ -20,6 +20,8 @@
 	final FormNavigatorEntry formNavigatorEntry = formNavigatorEntries.get(0);
 
 	String sectionId = namespace + _getSectionId(formNavigatorEntry.getKey());
+
+	String errorSection = null;
 	%>
 
 	<!-- Begin fragment <%= sectionId %> -->
@@ -37,7 +39,7 @@
 
 			});
 
-		String errorSection = (String)request.getAttribute(WebKeys.ERROR_SECTION);
+		errorSection = (String)request.getAttribute(WebKeys.ERROR_SECTION);
 
 		if (Validator.equals(formNavigatorEntry.getKey(), errorSection)) {
 			request.setAttribute(WebKeys.ERROR_SECTION, null);
@@ -76,40 +78,47 @@
 		<!-- End fragment <%= sectionId %> -->
 
 	<%
-		String errorSection = (String)request.getAttribute(WebKeys.ERROR_SECTION);
+		String curErrorSection = (String)request.getAttribute(WebKeys.ERROR_SECTION);
 
-		if (Validator.equals(curFormNavigatorEntry.getKey(), errorSection)) {
-	%>
+		if (Validator.equals(_getSectionId(curFormNavigatorEntry.getKey()), _getSectionId(curErrorSection))) {
+			errorSection = curErrorSection;
 
-			<aui:script sandbox="<%= true %>">
-				var focusField;
-				var sectionContent = $('#<%= _getSectionId(errorSection) %>Content');
-
-				if (!sectionContent.hasClass('in')) {
-					sectionContent.collapse('show');
-				}
-
-				<%
-				String focusField = (String)request.getAttribute("liferay-ui:error:focusField");
-				%>
-
-				<c:choose>
-					<c:when test="<%= Validator.isNotNull(focusField) %>">
-						focusField = sectionContent.find('#<portlet:namespace /><%= focusField %>');
-					</c:when>
-					<c:otherwise>
-						focusField = sectionContent.find('input:not([type="hidden"]).field').first();
-					</c:otherwise>
-				</c:choose>
-
-				if (focusField) {
-					focusField.focus();
-				}
-			</aui:script>
-
-	<%
 			request.setAttribute(WebKeys.ERROR_SECTION, null);
 		}
+	}
+	%>
+
+	<%
+	if (Validator.isNotNull(errorSection)) {
+	%>
+
+		<aui:script sandbox="<%= true %>">
+			var focusField;
+			var sectionContent = $('#<%= _getSectionId(errorSection) %>Content');
+
+			if (!sectionContent.hasClass('in')) {
+				sectionContent.collapse('show');
+			}
+
+			<%
+			String focusField = (String)request.getAttribute("liferay-ui:error:focusField");
+			%>
+
+			<c:choose>
+				<c:when test="<%= Validator.isNotNull(focusField) %>">
+					focusField = sectionContent.find('#<portlet:namespace /><%= focusField %>');
+				</c:when>
+				<c:otherwise>
+					focusField = sectionContent.find('input:not([type="hidden"]).field').first();
+				</c:otherwise>
+			</c:choose>
+
+			if (focusField) {
+				focusField.focus();
+			}
+		</aui:script>
+
+	<%
 	}
 	%>
 

--- a/util-taglib/src/com/liferay/taglib/aui/FieldsetTag.java
+++ b/util-taglib/src/com/liferay/taglib/aui/FieldsetTag.java
@@ -73,14 +73,18 @@ public class FieldsetTag extends BaseFieldsetTag {
 	protected void setAttributes(HttpServletRequest request) {
 		super.setAttributes(request);
 
-		String panelId = StringPool.BLANK;
-
-		if (Validator.isNotNull(getLabel()) && getCollapsible()) {
-			panelId = PortalUtil.getUniqueElementId(
-				request, _getNamespace(), AUIUtil.normalizeId(getLabel()));
+		if (Validator.isNotNull(getId())) {
+			return;
 		}
 
-		setNamespacedAttribute(request, "panelId", panelId);
+		if (Validator.isNull(getLabel()) || !getCollapsible()) {
+			return;
+		}
+
+		String id = PortalUtil.getUniqueElementId(
+			request, _getNamespace(), AUIUtil.normalizeId(getLabel()));
+
+		setNamespacedAttribute(request, "id", id);
 	}
 
 	private String _getNamespace() {


### PR DESCRIPTION
This is an update for [LPS-64236](https://issues.liferay.com/browse/LPS-64236).

Hey @natecavanaugh, I believe this covers all functions of the old form navigator error-marking.  Once this goes in, we should also make sure that the error banners themselves show up fixed so that they are always visible (fixed to viewport) after focusing on the error field (and not at the top of the page out of view).  I have another pull for that once we're finished with this, but I didn't include it here since it's not really in the scope of this particular issue (plus it changes a few other components).

Regarding 3205a57, see https://github.com/liferay/liferay-portal/blob/master/portal-web/docroot/html/taglib/ui/tabs/end.jsp#L20

/cc @ealonso @pei-jung @blzaugg
