### PR TITLE
[TECHNICAL-SUPPORT] LPS-67654 Chat plugin shows newly arrived messages as unread when the page is refreshed

### DIFF
--- a/modules/apps/chat/chat-web/src/main/resources/META-INF/resources/js/main.js
+++ b/modules/apps/chat/chat-web/src/main/resources/META-INF/resources/js/main.js
@@ -371,7 +371,11 @@ AUI().use(
 				instance._statusMessage.text(statusMessage);
 			}
 
+			instance._chatInput.on('click', instance._click, instance);
 			instance._chatInput.on(['focus', 'keyup'], instance._keystroke, instance);
+
+			instance._chatOutput.on('click', instance._click, instance);
+
 		};
 
 		A.extend(
@@ -580,6 +584,10 @@ AUI().use(
 
 						chatInput.ancestor().height(height + 5);
 					}
+				},
+
+				_click: function () {
+					Liferay.Chat.Manager.savePanelSettings();
 				},
 
 				_keystroke: function(event) {
@@ -889,6 +897,12 @@ AUI().use(
 						}
 					);
 				}
+			},
+
+			savePanelSettings: function() {
+				var instance = this;
+
+				instance._saveSettings();
 			},
 
 			send: function(options, id) {


### PR DESCRIPTION
Hey @natecavanaugh 

I don't know who is in charge for reviewing of Chat related pull requests, but since you helped me once in solving a Chat issue, and I know you have expertise in Javascript, I'm sending this pull to you.
Please feel free to forward it to the right person.

The scenario is that if a user receives a message while the chat panel is open, closes the panel, and refreshes the page, the panel will reappear minimized and blinking as if a new messages had just arrived.
But in reality, no new message arrived since the user closed the chat panel. After opening it, the last message he sees is the one he got just before closing the panel.

The chat entry's flag field's value will indicate whether the entry is read or unread, 1 or 0, respectively.
These value are set when the Liferay.Poller.submitRequest is called, for example when a message is sent.
Each incoming message in that panel will marked as read.
However, if the user clicks on the panel of the incoming message, or in the chat input textarea, the messages are still not marked as read.

Therefore, to bring our Chat portlet's behavior closer to that of other chat application's, for example Facebook's,  I added a click listener to the _chatInput and _chatOutput, which will call the _saveSettings() method of Liferay.Chat.Manager. This will trigger a poller update, and ChatPollerProcessor will call StatusLocalServiceUtil.updateStatus(), where the flag values will be set.

I'm not sure if this is the correct way of solving this issue, but if you have any suggestions, please feel free to share it.

Thanks in advance!

Best regards,
István
