### PR TITLE
[TECHNICAL-SUPPORT] LPS-71741 Chat portlet inconsistent behaviour when changing page and close/reopen

### DIFF
--- a/modules/apps/chat/chat-api/src/main/java/com/liferay/chat/model/EntryModel.java
+++ b/modules/apps/chat/chat-api/src/main/java/com/liferay/chat/model/EntryModel.java
@@ -160,6 +160,21 @@ public interface EntryModel extends BaseModel<Entry> {
 	public void setContent(String content);
 
 	/**
+	 * Returns the entry uuid of this entry.
+	 *
+	 * @return the entry uuid of this entry
+	 */
+	@AutoEscape
+	public String getEntryUuid();
+
+	/**
+	 * Sets the entry uuid of this entry.
+	 *
+	 * @param entryUuid the entry uuid of this entry
+	 */
+	public void setEntryUuid(String entryUuid);
+
+	/**
 	 * Returns the flag of this entry.
 	 *
 	 * @return the flag of this entry

--- a/modules/apps/chat/chat-api/src/main/java/com/liferay/chat/model/EntrySoap.java
+++ b/modules/apps/chat/chat-api/src/main/java/com/liferay/chat/model/EntrySoap.java
@@ -37,6 +37,7 @@ public class EntrySoap implements Serializable {
 		soapModel.setFromUserId(model.getFromUserId());
 		soapModel.setToUserId(model.getToUserId());
 		soapModel.setContent(model.getContent());
+		soapModel.setEntryUuid(model.getEntryUuid());
 		soapModel.setFlag(model.getFlag());
 
 		return soapModel;
@@ -130,6 +131,14 @@ public class EntrySoap implements Serializable {
 		_content = content;
 	}
 
+	public String getEntryUuid() {
+		return _entryUuid;
+	}
+
+	public void setEntryUuid(String entryUuid) {
+		_entryUuid = entryUuid;
+	}
+
 	public int getFlag() {
 		return _flag;
 	}
@@ -143,5 +152,6 @@ public class EntrySoap implements Serializable {
 	private long _fromUserId;
 	private long _toUserId;
 	private String _content;
+	private String _entryUuid;
 	private int _flag;
 }

--- a/modules/apps/chat/chat-api/src/main/java/com/liferay/chat/model/EntryWrapper.java
+++ b/modules/apps/chat/chat-api/src/main/java/com/liferay/chat/model/EntryWrapper.java
@@ -61,6 +61,7 @@ public class EntryWrapper implements Entry, ModelWrapper<Entry> {
 		attributes.put("fromUserId", getFromUserId());
 		attributes.put("toUserId", getToUserId());
 		attributes.put("content", getContent());
+		attributes.put("entryUuid", getEntryUuid());
 		attributes.put("flag", getFlag());
 
 		return attributes;
@@ -96,6 +97,12 @@ public class EntryWrapper implements Entry, ModelWrapper<Entry> {
 
 		if (content != null) {
 			setContent(content);
+		}
+
+		String entryUuid = (String)attributes.get("entryUuid");
+
+		if (entryUuid != null) {
+			setEntryUuid(entryUuid);
 		}
 
 		Integer flag = (Integer)attributes.get("flag");
@@ -178,6 +185,16 @@ public class EntryWrapper implements Entry, ModelWrapper<Entry> {
 	@Override
 	public java.lang.String getContent() {
 		return _entry.getContent();
+	}
+
+	/**
+	* Returns the entry uuid of this entry.
+	*
+	* @return the entry uuid of this entry
+	*/
+	@Override
+	public java.lang.String getEntryUuid() {
+		return _entry.getEntryUuid();
 	}
 
 	/**
@@ -298,6 +315,16 @@ public class EntryWrapper implements Entry, ModelWrapper<Entry> {
 	@Override
 	public void setEntryId(long entryId) {
 		_entry.setEntryId(entryId);
+	}
+
+	/**
+	* Sets the entry uuid of this entry.
+	*
+	* @param entryUuid the entry uuid of this entry
+	*/
+	@Override
+	public void setEntryUuid(java.lang.String entryUuid) {
+		_entry.setEntryUuid(entryUuid);
 	}
 
 	@Override

--- a/modules/apps/chat/chat-api/src/main/java/com/liferay/chat/service/EntryLocalService.java
+++ b/modules/apps/chat/chat-api/src/main/java/com/liferay/chat/service/EntryLocalService.java
@@ -73,6 +73,9 @@ public interface EntryLocalService extends BaseLocalService,
 	public Entry addEntry(long createDate, long fromUserId, long toUserId,
 		java.lang.String content);
 
+	public Entry addEntry(long createDate, long fromUserId, long toUserId,
+		java.lang.String content, java.lang.String entryUuid);
+
 	public Entry addEntry(long fromUserId, long toUserId,
 		java.lang.String content);
 

--- a/modules/apps/chat/chat-api/src/main/java/com/liferay/chat/service/EntryLocalServiceUtil.java
+++ b/modules/apps/chat/chat-api/src/main/java/com/liferay/chat/service/EntryLocalServiceUtil.java
@@ -58,6 +58,14 @@ public class EntryLocalServiceUtil {
 		return getService().addEntry(createDate, fromUserId, toUserId, content);
 	}
 
+	public static com.liferay.chat.model.Entry addEntry(long createDate,
+		long fromUserId, long toUserId, java.lang.String content,
+		java.lang.String entryUuid) {
+		return getService()
+				   .addEntry(createDate, fromUserId, toUserId, content,
+			entryUuid);
+	}
+
 	public static com.liferay.chat.model.Entry addEntry(long fromUserId,
 		long toUserId, java.lang.String content) {
 		return getService().addEntry(fromUserId, toUserId, content);

--- a/modules/apps/chat/chat-api/src/main/java/com/liferay/chat/service/EntryLocalServiceWrapper.java
+++ b/modules/apps/chat/chat-api/src/main/java/com/liferay/chat/service/EntryLocalServiceWrapper.java
@@ -52,6 +52,14 @@ public class EntryLocalServiceWrapper implements EntryLocalService,
 	}
 
 	@Override
+	public com.liferay.chat.model.Entry addEntry(long createDate,
+		long fromUserId, long toUserId, java.lang.String content,
+		java.lang.String entryUuid) {
+		return _entryLocalService.addEntry(createDate, fromUserId, toUserId,
+			content, entryUuid);
+	}
+
+	@Override
 	public com.liferay.chat.model.Entry addEntry(long fromUserId,
 		long toUserId, java.lang.String content) {
 		return _entryLocalService.addEntry(fromUserId, toUserId, content);

--- a/modules/apps/chat/chat-service/service.xml
+++ b/modules/apps/chat/chat-service/service.xml
@@ -18,6 +18,7 @@
 		<column name="fromUserId" type="long" />
 		<column name="toUserId" type="long" />
 		<column name="content" type="String" />
+		<column name="entryUuid" type="String" />
 		<column name="flag" type="int" />
 
 		<!-- Order -->

--- a/modules/apps/chat/chat-service/src/main/java/com/liferay/chat/internal/poller/ChatPollerProcessor.java
+++ b/modules/apps/chat/chat-service/src/main/java/com/liferay/chat/internal/poller/ChatPollerProcessor.java
@@ -79,11 +79,12 @@ public class ChatPollerProcessor extends BasePollerProcessor {
 	protected void addEntry(PollerRequest pollerRequest) throws Exception {
 		long toUserId = getLong(pollerRequest, "toUserId");
 		String content = getString(pollerRequest, "content");
+		String entryUuid = getString(pollerRequest, "entryUuid");
 
 		if (toUserId > 0) {
 			EntryLocalServiceUtil.addEntry(
 				pollerRequest.getTimestamp(), pollerRequest.getUserId(),
-				toUserId, content);
+				toUserId, content, entryUuid);
 		}
 	}
 
@@ -237,6 +238,7 @@ public class ChatPollerProcessor extends BasePollerProcessor {
 			}
 
 			entryJSONObject.put("content", HtmlUtil.escape(entry.getContent()));
+			entryJSONObject.put("entryUuid", entry.getEntryUuid());
 			entryJSONObject.put("flag", entry.getFlag());
 			entryJSONObject.put("toUserId", entry.getToUserId());
 

--- a/modules/apps/chat/chat-service/src/main/java/com/liferay/chat/model/impl/EntryCacheModel.java
+++ b/modules/apps/chat/chat-service/src/main/java/com/liferay/chat/model/impl/EntryCacheModel.java
@@ -63,7 +63,7 @@ public class EntryCacheModel implements CacheModel<Entry>, Externalizable {
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(13);
+		StringBundler sb = new StringBundler(15);
 
 		sb.append("{entryId=");
 		sb.append(entryId);
@@ -75,6 +75,8 @@ public class EntryCacheModel implements CacheModel<Entry>, Externalizable {
 		sb.append(toUserId);
 		sb.append(", content=");
 		sb.append(content);
+		sb.append(", entryUuid=");
+		sb.append(entryUuid);
 		sb.append(", flag=");
 		sb.append(flag);
 		sb.append("}");
@@ -98,6 +100,13 @@ public class EntryCacheModel implements CacheModel<Entry>, Externalizable {
 			entryImpl.setContent(content);
 		}
 
+		if (entryUuid == null) {
+			entryImpl.setEntryUuid(StringPool.BLANK);
+		}
+		else {
+			entryImpl.setEntryUuid(entryUuid);
+		}
+
 		entryImpl.setFlag(flag);
 
 		entryImpl.resetOriginalValues();
@@ -115,6 +124,7 @@ public class EntryCacheModel implements CacheModel<Entry>, Externalizable {
 
 		toUserId = objectInput.readLong();
 		content = objectInput.readUTF();
+		entryUuid = objectInput.readUTF();
 
 		flag = objectInput.readInt();
 	}
@@ -137,6 +147,13 @@ public class EntryCacheModel implements CacheModel<Entry>, Externalizable {
 			objectOutput.writeUTF(content);
 		}
 
+		if (entryUuid == null) {
+			objectOutput.writeUTF(StringPool.BLANK);
+		}
+		else {
+			objectOutput.writeUTF(entryUuid);
+		}
+
 		objectOutput.writeInt(flag);
 	}
 
@@ -145,5 +162,6 @@ public class EntryCacheModel implements CacheModel<Entry>, Externalizable {
 	public long fromUserId;
 	public long toUserId;
 	public String content;
+	public String entryUuid;
 	public int flag;
 }

--- a/modules/apps/chat/chat-service/src/main/java/com/liferay/chat/model/impl/EntryModelImpl.java
+++ b/modules/apps/chat/chat-service/src/main/java/com/liferay/chat/model/impl/EntryModelImpl.java
@@ -68,6 +68,7 @@ public class EntryModelImpl extends BaseModelImpl<Entry> implements EntryModel {
 			{ "fromUserId", Types.BIGINT },
 			{ "toUserId", Types.BIGINT },
 			{ "content", Types.VARCHAR },
+			{ "entryUuid", Types.VARCHAR },
 			{ "flag", Types.INTEGER }
 		};
 	public static final Map<String, Integer> TABLE_COLUMNS_MAP = new HashMap<String, Integer>();
@@ -78,10 +79,11 @@ public class EntryModelImpl extends BaseModelImpl<Entry> implements EntryModel {
 		TABLE_COLUMNS_MAP.put("fromUserId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("toUserId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("content", Types.VARCHAR);
+		TABLE_COLUMNS_MAP.put("entryUuid", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("flag", Types.INTEGER);
 	}
 
-	public static final String TABLE_SQL_CREATE = "create table Chat_Entry (entryId LONG not null primary key,createDate LONG,fromUserId LONG,toUserId LONG,content VARCHAR(1000) null,flag INTEGER)";
+	public static final String TABLE_SQL_CREATE = "create table Chat_Entry (entryId LONG not null primary key,createDate LONG,fromUserId LONG,toUserId LONG,content VARCHAR(1000) null,entryUuid VARCHAR(75) null,flag INTEGER)";
 	public static final String TABLE_SQL_DROP = "drop table Chat_Entry";
 	public static final String ORDER_BY_JPQL = " ORDER BY entry.createDate DESC";
 	public static final String ORDER_BY_SQL = " ORDER BY Chat_Entry.createDate DESC";
@@ -146,6 +148,7 @@ public class EntryModelImpl extends BaseModelImpl<Entry> implements EntryModel {
 		attributes.put("fromUserId", getFromUserId());
 		attributes.put("toUserId", getToUserId());
 		attributes.put("content", getContent());
+		attributes.put("entryUuid", getEntryUuid());
 		attributes.put("flag", getFlag());
 
 		attributes.put("entityCacheEnabled", isEntityCacheEnabled());
@@ -184,6 +187,12 @@ public class EntryModelImpl extends BaseModelImpl<Entry> implements EntryModel {
 
 		if (content != null) {
 			setContent(content);
+		}
+
+		String entryUuid = (String)attributes.get("entryUuid");
+
+		if (entryUuid != null) {
+			setEntryUuid(entryUuid);
 		}
 
 		Integer flag = (Integer)attributes.get("flag");
@@ -327,6 +336,21 @@ public class EntryModelImpl extends BaseModelImpl<Entry> implements EntryModel {
 	}
 
 	@Override
+	public String getEntryUuid() {
+		if (_entryUuid == null) {
+			return StringPool.BLANK;
+		}
+		else {
+			return _entryUuid;
+		}
+	}
+
+	@Override
+	public void setEntryUuid(String entryUuid) {
+		_entryUuid = entryUuid;
+	}
+
+	@Override
 	public int getFlag() {
 		return _flag;
 	}
@@ -372,6 +396,7 @@ public class EntryModelImpl extends BaseModelImpl<Entry> implements EntryModel {
 		entryImpl.setFromUserId(getFromUserId());
 		entryImpl.setToUserId(getToUserId());
 		entryImpl.setContent(getContent());
+		entryImpl.setEntryUuid(getEntryUuid());
 		entryImpl.setFlag(getFlag());
 
 		entryImpl.resetOriginalValues();
@@ -480,6 +505,14 @@ public class EntryModelImpl extends BaseModelImpl<Entry> implements EntryModel {
 			entryCacheModel.content = null;
 		}
 
+		entryCacheModel.entryUuid = getEntryUuid();
+
+		String entryUuid = entryCacheModel.entryUuid;
+
+		if ((entryUuid != null) && (entryUuid.length() == 0)) {
+			entryCacheModel.entryUuid = null;
+		}
+
 		entryCacheModel.flag = getFlag();
 
 		return entryCacheModel;
@@ -487,7 +520,7 @@ public class EntryModelImpl extends BaseModelImpl<Entry> implements EntryModel {
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(13);
+		StringBundler sb = new StringBundler(15);
 
 		sb.append("{entryId=");
 		sb.append(getEntryId());
@@ -499,6 +532,8 @@ public class EntryModelImpl extends BaseModelImpl<Entry> implements EntryModel {
 		sb.append(getToUserId());
 		sb.append(", content=");
 		sb.append(getContent());
+		sb.append(", entryUuid=");
+		sb.append(getEntryUuid());
 		sb.append(", flag=");
 		sb.append(getFlag());
 		sb.append("}");
@@ -508,7 +543,7 @@ public class EntryModelImpl extends BaseModelImpl<Entry> implements EntryModel {
 
 	@Override
 	public String toXmlString() {
-		StringBundler sb = new StringBundler(22);
+		StringBundler sb = new StringBundler(25);
 
 		sb.append("<model><model-name>");
 		sb.append("com.liferay.chat.model.Entry");
@@ -533,6 +568,10 @@ public class EntryModelImpl extends BaseModelImpl<Entry> implements EntryModel {
 		sb.append(
 			"<column><column-name>content</column-name><column-value><![CDATA[");
 		sb.append(getContent());
+		sb.append("]]></column-value></column>");
+		sb.append(
+			"<column><column-name>entryUuid</column-name><column-value><![CDATA[");
+		sb.append(getEntryUuid());
 		sb.append("]]></column-value></column>");
 		sb.append(
 			"<column><column-name>flag</column-name><column-value><![CDATA[");
@@ -560,6 +599,7 @@ public class EntryModelImpl extends BaseModelImpl<Entry> implements EntryModel {
 	private boolean _setOriginalToUserId;
 	private String _content;
 	private String _originalContent;
+	private String _entryUuid;
 	private int _flag;
 	private long _columnBitmask;
 	private Entry _escapedModel;

--- a/modules/apps/chat/chat-service/src/main/java/com/liferay/chat/service/impl/EntryLocalServiceImpl.java
+++ b/modules/apps/chat/chat-service/src/main/java/com/liferay/chat/service/impl/EntryLocalServiceImpl.java
@@ -34,6 +34,16 @@ public class EntryLocalServiceImpl extends EntryLocalServiceBaseImpl {
 	public Entry addEntry(
 		long createDate, long fromUserId, long toUserId, String content) {
 
+		String entryUuid = StringPool.BLANK;
+
+		return addEntry(createDate, fromUserId, toUserId, content, entryUuid);
+	}
+
+	@Override
+	public Entry addEntry(
+		long createDate, long fromUserId, long toUserId, String content,
+		String entryUuid) {
+
 		List<Entry> entries = entryFinder.findByEmptyContent(
 			fromUserId, toUserId, 0, 5);
 
@@ -60,6 +70,10 @@ public class EntryLocalServiceImpl extends EntryLocalServiceBaseImpl {
 			}
 		}
 
+		if (Validator.isNull(entryUuid)) {
+			entryUuid = StringPool.BLANK;
+		}
+
 		long entryId = counterLocalService.increment();
 
 		Entry entry = entryPersistence.create(entryId);
@@ -68,6 +82,7 @@ public class EntryLocalServiceImpl extends EntryLocalServiceBaseImpl {
 		entry.setFromUserId(fromUserId);
 		entry.setToUserId(toUserId);
 		entry.setContent(content);
+		entry.setEntryUuid(entryUuid);
 
 		entryPersistence.update(entry);
 

--- a/modules/apps/chat/chat-service/src/main/java/com/liferay/chat/service/persistence/impl/EntryPersistenceImpl.java
+++ b/modules/apps/chat/chat-service/src/main/java/com/liferay/chat/service/persistence/impl/EntryPersistenceImpl.java
@@ -4859,6 +4859,7 @@ public class EntryPersistenceImpl extends BasePersistenceImpl<Entry>
 		entryImpl.setFromUserId(entry.getFromUserId());
 		entryImpl.setToUserId(entry.getToUserId());
 		entryImpl.setContent(entry.getContent());
+		entryImpl.setEntryUuid(entry.getEntryUuid());
 		entryImpl.setFlag(entry.getFlag());
 
 		return entryImpl;

--- a/modules/apps/chat/chat-service/src/main/resources/META-INF/module-hbm.xml
+++ b/modules/apps/chat/chat-service/src/main/resources/META-INF/module-hbm.xml
@@ -12,6 +12,7 @@
 		<property name="fromUserId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property name="toUserId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property name="content" type="com.liferay.portal.dao.orm.hibernate.StringType" />
+		<property name="entryUuid" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property name="flag" type="com.liferay.portal.dao.orm.hibernate.IntegerType" />
 	</class>
 	<class name="com.liferay.chat.model.impl.StatusImpl" table="Chat_Status">

--- a/modules/apps/chat/chat-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/apps/chat/chat-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -9,6 +9,7 @@
 		<field name="content" type="String">
 			<hint name="max-length">1000</hint>
 		</field>
+		<field name="entryUuid" type="String" />
 		<field name="flag" type="int" />
 	</model>
 	<model name="com.liferay.chat.model.Status">

--- a/modules/apps/chat/chat-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/apps/chat/chat-service/src/main/resources/META-INF/sql/tables.sql
@@ -4,6 +4,7 @@ create table Chat_Entry (
 	fromUserId LONG,
 	toUserId LONG,
 	content VARCHAR(1000) null,
+	entryUuid VARCHAR(75) null,
 	flag INTEGER
 );
 

--- a/modules/apps/chat/chat-test/src/testIntegration/java/com/liferay/chat/service/persistence/test/EntryPersistenceTest.java
+++ b/modules/apps/chat/chat-test/src/testIntegration/java/com/liferay/chat/service/persistence/test/EntryPersistenceTest.java
@@ -130,6 +130,8 @@ public class EntryPersistenceTest {
 
 		newEntry.setContent(RandomTestUtil.randomString());
 
+		newEntry.setEntryUuid(RandomTestUtil.randomString());
+
 		newEntry.setFlag(RandomTestUtil.nextInt());
 
 		_entries.add(_persistence.update(newEntry));
@@ -143,6 +145,8 @@ public class EntryPersistenceTest {
 			newEntry.getFromUserId());
 		Assert.assertEquals(existingEntry.getToUserId(), newEntry.getToUserId());
 		Assert.assertEquals(existingEntry.getContent(), newEntry.getContent());
+		Assert.assertEquals(existingEntry.getEntryUuid(),
+			newEntry.getEntryUuid());
 		Assert.assertEquals(existingEntry.getFlag(), newEntry.getFlag());
 	}
 
@@ -234,7 +238,7 @@ public class EntryPersistenceTest {
 	protected OrderByComparator<Entry> getOrderByComparator() {
 		return OrderByComparatorFactoryUtil.create("Chat_Entry", "entryId",
 			true, "createDate", true, "fromUserId", true, "toUserId", true,
-			"content", true, "flag", true);
+			"content", true, "entryUuid", true, "flag", true);
 	}
 
 	@Test
@@ -437,6 +441,8 @@ public class EntryPersistenceTest {
 		entry.setToUserId(RandomTestUtil.nextLong());
 
 		entry.setContent(RandomTestUtil.randomString());
+
+		entry.setEntryUuid(RandomTestUtil.randomString());
 
 		entry.setFlag(RandomTestUtil.nextInt());
 

--- a/modules/apps/chat/chat-web/src/main/resources/META-INF/resources/js/main.js
+++ b/modules/apps/chat/chat-web/src/main/resources/META-INF/resources/js/main.js
@@ -642,9 +642,14 @@ AUI().use(
 
 					var escapedHTML = LString.escapeHTML(content);
 
+					var uuid = themeDisplay.getUserId() + ":" + userId + ":" + createDate + ":" + Liferay.Util.randomInt();
+
+					Liferay.Chat.Manager.addEntryUuid(uuid);
+
 					instance.send(
 						{
 							content: content,
+							entryUuid: uuid,
 							toUserId: userId
 						}
 					);
@@ -818,6 +823,12 @@ AUI().use(
 						name: 'chat-user-dashboard-service'
 					}
 				);
+			},
+
+			addEntryUuid: function(uuid) {
+				var instance = this;
+
+				instance._entryUuids.push(uuid);
 			},
 
 			getContainer: function() {
@@ -1577,6 +1588,12 @@ AUI().use(
 							);
 						}
 
+						var entryUuids = instance._entryUuids;
+
+						var entryUuid = entry.entryUuid;
+
+						var entryEchoed = entryUuids.indexOf(entryUuid) > -1;
+
 						var incoming = false;
 
 						var userId = entry.toUserId;
@@ -1589,7 +1606,7 @@ AUI().use(
 
 						var buddy = instance._buddies[userId];
 
-						if (buddy && (incoming || key != windowId)) {
+						if (buddy && (entryEchoed || key != windowId)) {
 							var chat = instance._chatSessions[userId];
 
 							var content = entry.content;
@@ -1694,6 +1711,7 @@ AUI().use(
 			_buddyServices: {},
 			_chatSessions: {},
 			_entries: [],
+			_entryUuids: [],
 			_minimizedPanelIds: {},
 			_panels: {},
 			_settings: {},


### PR DESCRIPTION
Hey @natecavanaugh 

Following your suggestions, I added an new UUID field to the Chat Entry model and extended the service API call with it.
On the frontend (**main.js**), when the entries are polled from the backend, `entryUuid` is used to check if an outgoing message was echoed on the chat window. In that is the case, the message is skipped when updating the window with the messages list.

After extending the API, I had some problems with compiling **chat-api** and **chat-service** though.

**chat-service** failed because it could not recognize the new field and methods in the API, I think because **chat-api** could not compiled in the first place.
chat-api in turn fails with this error during the source code processing via findBugsMain:

```
The following errors occurred during analysis:
  Cannot open codebase filesystem:C:\repok\liferay-portal\modules\apps\chat\chat-api\classes\com\liferay\chat\constants\packageinfo
    java.io.IOException: Wrong magic bytes of 76657273 for zip file C:\repok\liferay-portal\modules\apps\chat\chat-api\classes\com\liferay\chat\constants\packageinfo of 13 bytes
      At edu.umd.cs.findbugs.classfile.impl.ZipFileCodeBase.<init>(ZipFileCodeBase.java:87)
```

findBugsMain fails also if the API is not changed.

Have you ever met with this kind of compilation error in the Chat module?

Also, could you please check if the overall solution is OK?

Thank you very much!

Best regards,
István
